### PR TITLE
商品一覧機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    # @items = Item.order('created_at DESC')
+    # @items = Item.all
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,4 +24,8 @@ class Item < ApplicationRecord
   validates :postage_payer_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
   validates :prefecture_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
   validates :ship_date_estimate_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
+
+  # def sold_out?
+  #   order_id.present?
+  # end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,24 +129,27 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <%# <% if item.sold_out? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <%# <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.postage_payer.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +158,10 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +179,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,4 +105,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_03_030806) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "items", "users"
 end


### PR DESCRIPTION
# What
　商品一覧機能のルーティング、コントローラー、ビューの設定
　soldoutはコメントアウトで記載

# Why
　商品一覧機能実装のため。

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/3ca3992acfe162fe65851238ecaba599

商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/0b81c8f2a37e856debb836d9e5905491